### PR TITLE
Center the Country name vertically

### DIFF
--- a/shared/src/commonMain/kotlin/com/example/traveapp_kmp/listing/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/example/traveapp_kmp/listing/MainScreen.kt
@@ -192,12 +192,15 @@ private fun CountryChips(name: String, isSelected: Boolean, onItemSelected: (Str
         ),
         color = if (isSelected) TravelAppColors.SemiWhite else Color.Transparent,
         onClick = { onItemSelected(name) }) {
-        Text(
-            name,
-            style = MaterialTheme.typography.body1.copy(color = Color.Black),
-            modifier = Modifier.padding(start = 24.dp, top = 8.dp, bottom = 8.dp, end = 24.dp)
-                .background(Color.Transparent),
-        )
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text(
+                name,
+                style = MaterialTheme.typography.body1.copy(color = Color.Black),
+                modifier = Modifier.padding(start = 24.dp, end = 24.dp)
+                    .background(Color.Transparent),
+                textAlign = TextAlign.Center
+            )
+        }
     }
 }
 


### PR DESCRIPTION
A small fix to center Country name vertically.

Before change : 
<img width="455" alt="Screenshot 2023-05-13 at 00 20 55" src="https://github.com/SEAbdulbasit/TravelApp-KMP/assets/1329281/4713d16a-71ee-4d34-832e-18a52b46246d">

 