### PR TITLE
Updated screen navigation with jetpack navigation library implementation

### DIFF
--- a/shared/src/commonMain/kotlin/com/example/travelapp_kmp/MainView.kt
+++ b/shared/src/commonMain/kotlin/com/example/travelapp_kmp/MainView.kt
@@ -1,9 +1,13 @@
 package com.example.travelapp_kmp
 
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import com.example.travelapp_kmp.details.DetailScreen
 import com.example.travelapp_kmp.details.DetailScreenWeb
 import com.example.travelapp_kmp.listing.ListScreenViewModel
@@ -14,56 +18,30 @@ import com.example.travelapp_kmp.listing.TouristPlace
 @Composable
 internal fun CommonView(isLargeScreen: Boolean = false) {
     val viewMode = remember { ListScreenViewModel() }
-//    val navController = rememberNavController()
+    val navController = rememberNavController()
     var selectedTouristPlace: TouristPlace? = null
-    val currentScreen = remember { mutableStateOf(AppScreen.List) }
 
     MaterialTheme {
-        when (currentScreen.value) {
-            AppScreen.List -> {
+        NavHost(
+            navController = navController,
+            startDestination = AppScreen.List.name,
+            modifier = Modifier.fillMaxSize()
+        ) {
+            composable(AppScreen.List.name) {
                 MainScreen(navigateToDetails = {
                     selectedTouristPlace = it
-                    currentScreen.value = AppScreen.Details
-//                    navController.navigate(AppScreen.Details.name)
+                    navController.navigate(AppScreen.Details.name)
                 }, viewMode = viewMode)
             }
-
-            AppScreen.Details -> {
+            composable(AppScreen.Details.name) {
                 if (isLargeScreen)
                     DetailScreenWeb(touristPlace = selectedTouristPlace!!,
-                        navigateBack = {
-                            currentScreen.value = AppScreen.List
-//                            navController.popBackStack()
-                        })
+                        navigateBack = { navController.popBackStack() })
                 else
                     DetailScreen(touristPlace = selectedTouristPlace!!,
-                        navigateBack = {
-                            currentScreen.value = AppScreen.List
-//                            navController.popBackStack()
-                        })
+                        navigateBack = { navController.popBackStack() })
             }
         }
-
-//        NavHost(
-//            navController = navController,
-//            startDestination = AppScreen.List.name,
-//            modifier = Modifier.fillMaxSize()
-//        ) {
-//            composable(AppScreen.List.name) {
-//                MainScreen(navigateToDetails = {
-//                    selectedTouristPlace = it
-//                    navController.navigate(AppScreen.Details.name)
-//                }, viewMode = viewMode)
-//            }
-//            composable(AppScreen.Details.name) {
-//                if (isLargeScreen)
-//                    DetailScreenWeb(touristPlace = selectedTouristPlace!!,
-//                        navigateBack = { navController.popBackStack() })
-//                else
-//                    DetailScreen(touristPlace = selectedTouristPlace!!,
-//                        navigateBack = { navController.popBackStack() })
-//            }
-//        }
     }
 }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

<!--
For pull requests that relate to or close an issue, please include them
below. For example: "closes #1234".
-->

## Related Issues & Documents
Fixes #55

## Description
Hi @SEAbdulbasit,
Earlier, when the user use to comes back from DetailScreen to MainScreenView, it was recomposing MainScreenView every time. This was resulting into inconsistent UI state and user experience. Now, after updating the navigation logic with Jetpack navigation code, that was commented earlier, it is working fine and the UI contents appearing as expected.

## Code Changes
In [MainView.kt](https://github.com/SEAbdulbasit/TravelApp-KMP/blob/master/shared/src/commonMain/kotlin/com/example/travelapp_kmp/MainView.kt) file, manual navigation logic updated with Jetpack navigation code.


## Screenshots, Recordings
### Before change

| Android | iOS |
| :---: | :---: | 
| <video src = "https://github.com/user-attachments/assets/7b8dd686-c1f6-45c8-b3b4-eda8ea878400" height= "200" width="100"> | <video src = "https://github.com/user-attachments/assets/397a99b7-91ab-4872-81d9-74e2c6ff9a18" height= "200" width="100"> |

| Desktop | Web |
| :---: | :---: | 
| https://drive.google.com/file/d/1HK1nRI_43Z5rwGnJHajZNwBACbePB75-/view?usp=sharing | https://drive.google.com/file/d/1vZtG4cc556TuG8UnEyrE9Z1crDx2p4-4/view?usp=sharing |

### After change

| Android | iOS |
| :---: | :---: | 
| <video src = "https://github.com/user-attachments/assets/617bb0e8-9577-4631-b3ee-67510db1e39f" height= "200" width="100"> | <video src = "https://github.com/user-attachments/assets/bbfb837a-3735-4b21-b0a3-7eed641bc821" height= "200" width="100"> |

| Desktop | Web |
| :---: | :---: | 
| https://drive.google.com/file/d/1G1qFhc0otcKLU-KTXh2G_iIYijNLQP64/view?usp=sharing | https://drive.google.com/file/d/1sZwjvHzBxz2SLw9z3r5p_-UFHdIJKd6D/view?usp=sharing |
